### PR TITLE
オブジェクト指向版 lsコマンド作成

### DIFF
--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'etc'
+
+module LS
+  class File
+    attr_reader :files
+
+    def initialize
+      @files = Dir.glob('*').sort
+    end
+
+    def all(files)
+      Dir.glob('.*').sort + files
+    end
+
+    def reverse(files)
+      files.reverse
+    end
+
+    def data(files)
+      fdata = []
+      files.each do |fname|
+        fstat = ::File::Stat.new(fname)
+        fdata.push [
+          permission_convert(fstat),
+          fstat.nlink.to_s.rjust(nlink_length(files)),
+          Etc.getpwuid(fstat.uid).name,
+          Etc.getgrgid(fstat.gid).name.rjust(6),
+          fstat.size.to_s.rjust(5),
+          fstat.mtime.strftime('%_m %e %H:%M'),
+          fname
+        ]
+      end
+      fdata
+    end
+
+    private
+
+    def nlink_length(files)
+      max_length = []
+      files.each do |fname|
+        fstat = ::File::Stat.new(fname)
+        max_length << fstat.nlink
+      end
+      max_length.max_by { |num| num.to_s.length }.to_s.length
+    end
+
+    def permission_convert(fstat)
+      type = fstat.ftype == 'file' ? '-' : fstat.ftype[0]
+      rwx = { '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx',
+              '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx' }
+      mode = fstat.mode.to_s(8)[-3, 3].gsub(/\d/, rwx)
+      "#{type}#{mode} "
+    end
+  end
+
+  class Command < File
+    attr_reader :options, :files
+
+    def initialize
+      super
+      @options = {}
+      opt = OptionParser.new
+      opt.on('-a', '--all') { |v| @options[:a] = v }
+      opt.on('-l', '--long') { |v| @options[:l] = v }
+      opt.on('-r', '--reverse') { |v| @options[:r] = v }
+      opt.parse(ARGV)
+    end
+
+    def select_option
+      if options[:a] == true
+        @files = all(files)
+      else
+        @files
+      end
+
+      @files = reverse(files) if options[:r] == true
+
+      if options[:l] == true
+        LS::VerticalFormatter.new.single_column(@files)
+      else
+        LS::HorizontalFormatter.new.multi_column(@files)
+      end
+    end
+  end
+
+  class HorizontalFormatter
+    def multi_column(files)
+      result = []
+      files.map { |fname| result << fname.to_s.ljust(24, ' ') }
+      format = result.each_slice(length(files)).to_a
+      push_nil(format).transpose.each { |a| puts a.join('') }
+    end
+
+    private
+
+    def length(files)
+      (files.length % 4).zero? ? files.length / 4 : files.length / 4 + 1
+    end
+
+    def push_nil(format)
+      max = format.max_by(&:length).length
+      format.each { |a| a[max - 1] = nil if a.length < max }
+    end
+  end
+
+  class VerticalFormatter
+    def total(files)
+      total = 0
+      files.each do |fname|
+        fstat = ::File::Stat.new(fname)
+        total += fstat.blocks
+      end
+      puts "total #{total}"
+    end
+
+    def single_column(files)
+      total(files)
+      fdata = LS::Command.new.data(files)
+      fdata.map { |a| puts a.each_slice(7).to_a.join(' ') }
+    end
+  end
+end
+
+LS::Command.new.select_option


### PR DESCRIPTION
## 内容
オブジェクト思考版のlsコマンドを作成を作成しました。
- LinuxコマンドのlsコマンドをRubyで作成する。
- `-a` `-l` `-r`オプションを実装する。
- `-alr`でも`-lra`でも`-ral`でも順番に関係なく実行できる。
- `rubocop-fjord`をパスさせる。

## Terminalの実行結果
### オプションなし
<img width="621" alt="スクリーンショット 2021-03-08 7 18 52" src="https://user-images.githubusercontent.com/53958282/110325419-aba41000-805a-11eb-9f6d-7ce804f36216.png">

### -aオプション
<img width="621" alt="スクリーンショット 2021-03-08 7 19 30" src="https://user-images.githubusercontent.com/53958282/110325437-b199f100-805a-11eb-951f-c0794dc382ac.png">

### -rオプション
<img width="621" alt="スクリーンショット 2021-03-08 7 20 06" src="https://user-images.githubusercontent.com/53958282/110325521-ca0a0b80-805a-11eb-9751-2e48ad09c455.png">

### -lオプション
<img width="621" alt="スクリーンショット 2021-03-08 7 20 41" src="https://user-images.githubusercontent.com/53958282/110325574-d8f0be00-805a-11eb-9e5b-891c972ae284.png">

### -alrオプション
<img width="621" alt="スクリーンショット 2021-03-08 7 21 27" src="https://user-images.githubusercontent.com/53958282/110325685-faea4080-805a-11eb-84d1-3497d611a094.png">

<img width="621" alt="スクリーンショット 2021-03-08 7 36 03" src="https://user-images.githubusercontent.com/53958282/110325724-0473a880-805b-11eb-84a1-b79537c73e75.png">
