### PR TITLE
Calendar Practice

### DIFF
--- a/02.calendar/calendar_date_unit.rb
+++ b/02.calendar/calendar_date_unit.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CalenderDateUnit
+class CalendarDateUnit
   THIS_Y = Date.today.year
   THIS_M = Date.today.mon
   THIS_D = Date.today.day

--- a/02.calendar/calender_date_unit.rb
+++ b/02.calendar/calender_date_unit.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class CalenderDateUnit
+  THIS_Y = Date.today.year
+  THIS_M = Date.today.mon
+  THIS_D = Date.today.day
+  THIS_W = Date.today.wday
+
+  def initialize(month, year, request)
+    @year = year
+    @month = month
+    @request = request
+  end
+
+  def generate_days
+    month_last_d = Date.new(@year, @month, -1).day
+
+    days_array = []
+    days_array = generate_one_month_days(days_array, month_last_d)
+    optimized_days_array = add_blank(days_array)
+
+    [@month, @year, optimized_days_array]
+  end
+
+  private
+
+  def generate_one_month_days(days_array, month_last_d)
+    case @request[:julius]
+    when true
+      j_month_first_d = Date.new(@year, @month, 1).yday
+      j_month_last_d = Date.new(@year, @month, month_last_d).yday
+      days_array << [*j_month_first_d..j_month_last_d]
+    when false
+      days_array << [*1..month_last_d]
+    end
+    days_array.flatten!
+    days_array
+  end
+
+  def add_blank(days_array)
+    month_first_w = Date.new(@year, @month, 1).wday
+    optimized_days_array_result = []
+
+    month_first_w.times { days_array.unshift('blank') }
+
+    days_array.each do |day|
+      case
+      when day == 'blank'
+        optimized_days_array_result << "#{day}\s"
+      when day.to_s.length == 1
+        if turn_on_highlight(day, @request[:highligth])
+          optimized_days_array_result << "\e[47m\e[30mblank_for_one_char#{day}\e[0m\s"
+          next
+        end
+        optimized_days_array_result << "blank_for_one_char#{day}\s"
+      when day.to_s.length == 2
+        if turn_on_highlight(day, @request[:highligth])
+          optimized_days_array_result << "\e\e[47m\e[30mblank_for_two_char#{day}\e[0m\s"
+          next
+        end
+        optimized_days_array_result << "blank_for_two_char#{day}\s"
+      when day.to_s.length == 3
+        if turn_on_highlight_when_j(day, @request[:highligth])
+          optimized_days_array_result << "\e\e[47m\e[30mblank_for_three_char#{day}\e[0m\s"
+          next
+        end
+        optimized_days_array_result << "blank_for_three_char#{day}\s"
+      end
+    end
+    optimized_days_array_result
+  end
+
+  def turn_on_highlight(day, highligth)
+    @year == THIS_Y && @month == THIS_M && day == THIS_D && highligth
+  end
+
+  def turn_on_highlight_when_j(day, highligth)
+    @year == THIS_Y && @month == THIS_M && day == Date.new(@year, @month, THIS_D).yday && highligth
+  end
+end

--- a/02.calendar/make_request.rb
+++ b/02.calendar/make_request.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require './optparse_run'
+require 'date'
+
+class MakeRequest
+  THIS_Y = Date.today.year
+  THIS_M = Date.today.mon
+  THIS_D = Date.today.day
+  THIS_W = Date.today.wday
+
+  def initialize
+    @generate_request_result = {}
+    @default_request_status = {
+      basic_month: THIS_M,
+      basic_year: THIS_Y,
+      basic_day: THIS_D,
+      pre_month: nil,
+      next_month: nil,
+      julius: false,
+      highligth: true,
+      year_position: 'default'
+    }
+  end
+
+  def make_request
+    parse_arge = OptparseRun.new(@default_request_status)
+    parse_arge.optparse_run
+  end
+end

--- a/02.calendar/merge_cal.rb
+++ b/02.calendar/merge_cal.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+class MergeCalender
+  THIS_Y = Date.today.year
+  THIS_M = Date.today.mon
+  THIS_D = Date.today.day
+  THIS_W = Date.today.wday
+
+  def initialize(all_dates, layout_status)
+    @all_dates = all_dates
+    @layout_status = layout_status
+  end
+
+  def merge
+    rendering_calender(@all_dates)
+  end
+
+  private
+
+  def rendering_calender(all_dates)
+    rendering_string_result = ''
+    replaced_all_dates = Marshal.load(Marshal.dump(all_dates))
+    replaced_all_dates = replace_layout_var(replaced_all_dates)
+
+    while replaced_all_dates.size / 3 >= 1 && @layout_status[:month_column_num] == 3
+      rendering_string_result += merge_date_unit(
+        3,
+        replaced_all_dates[0],
+        replaced_all_dates[1],
+        replaced_all_dates[2]
+      )
+      replaced_all_dates.slice!(0, 3)
+    end
+    while replaced_all_dates.size / 2 >= 1
+      rendering_string_result += merge_date_unit(
+        2,
+        replaced_all_dates[0],
+        replaced_all_dates[1]
+      )
+      replaced_all_dates.slice!(0, 2)
+    end
+    if replaced_all_dates.size >= 1
+      rendering_string_result += merge_date_unit(
+        1,
+        replaced_all_dates[0]
+      )
+      replaced_all_dates.slice!(0, 1)
+    end
+    rendering_string_result.insert(0, @layout_status[:header_position].call(@all_dates[0][1]))
+    rendering_string_result
+  end
+
+  def merge_date_unit(
+    merge_unit_num,
+    first_unit = nil,
+    second_unit = nil,
+    third_unit = nil
+  )
+    case merge_unit_num
+    when 1
+      first_day_cells = first_unit[2]
+
+      maxsize = [first_day_cells.size].max
+      column = decide_column(maxsize)
+
+      first_day_cells = add_end_blank(column, merge_unit_num, first_day_cells)
+      one_month_day_cells = Array.new(column).map { Array.new(7, nil) }
+      one_month_day_cells.map.each_with_index do |grid, index|
+        grid[0..6] = first_day_cells[index * 7..index * 7 + 6]
+      end
+      one_month_days_string_result = join_days_string(one_month_day_cells, column)
+
+      <<~CALENDER
+        #{@layout_status[:one_caption].call(first_unit[0], first_unit[1])}
+        #{@layout_status[:one_week]}
+        #{one_month_days_string_result}
+      CALENDER
+
+    when 2
+      first_day_cells = first_unit[2]
+      second_day_cells = second_unit[2]
+
+      maxsize = [first_day_cells.size, second_day_cells.size].max
+      column = decide_column(maxsize)
+
+      first_day_cells, second_day_cells = add_end_blank(column, merge_unit_num, first_day_cells, second_day_cells)
+
+      two_months_day_cells = Array.new(column).map { Array.new(14, nil) }
+      two_months_day_cells.map.each_with_index do |grid, index|
+        grid[0..6] = first_day_cells[index * 7..index * 7 + 6]
+        grid[7..13] = second_day_cells[index * 7..index * 7 + 6]
+        grid.insert(7, "\s")
+      end
+      two_month_days_string_result = join_days_string(two_months_day_cells, column)
+
+      <<~CALENDER
+        #{@layout_status[:two_caption].call(first_unit[0], first_unit[1], second_unit[0], second_unit[1])}
+        #{@layout_status[:two_weeks]}
+        #{two_month_days_string_result}
+      CALENDER
+
+    when 3
+      first_day_cells = first_unit[2]
+      second_day_cells = second_unit[2]
+      third_day_cells = third_unit[2]
+
+      maxsize = [first_day_cells.size, second_day_cells.size, third_day_cells.size].max
+      column = decide_column(maxsize)
+
+      first_day_cells, second_day_cells, third_day_cells = add_end_blank(
+        column,
+        merge_unit_num,
+        first_day_cells,
+        second_day_cells,
+        third_day_cells
+      )
+
+      three_months_day_cells = Array.new(column).map { Array.new(21, nil) }
+      three_months_day_cells.map.each_with_index do |grid, index|
+        grid[0..6] = first_day_cells[index * 7..index * 7 + 6]
+        grid[7..13] = second_day_cells[index * 7..index * 7 + 6]
+        grid[14..20] = third_day_cells[index * 7..index * 7 + 6]
+        grid.insert(14, "\s")
+        grid.insert(7, "\s")
+      end
+      three_month_days_string_result = join_days_string(three_months_day_cells, column)
+
+      <<~CALENDER
+        #{@layout_status[:three_caption].call(first_unit[0], first_unit[1], second_unit[0], second_unit[1], third_unit[0], third_unit[1])}
+        #{@layout_status[:three_weeks]}
+        #{three_month_days_string_result}
+      CALENDER
+    end
+  end
+
+  def join_days_string(day_cells, column)
+    case column
+    when 6
+      <<~CALENDER
+        #{day_cells[0].join}
+        #{day_cells[1].join}
+        #{day_cells[2].join}
+        #{day_cells[3].join}
+        #{day_cells[4].join}
+        #{day_cells[5].join}
+      CALENDER
+    when 5
+      <<~CALENDER
+        #{day_cells[0].join}
+        #{day_cells[1].join}
+        #{day_cells[2].join}
+        #{day_cells[3].join}
+        #{day_cells[4].join}
+      CALENDER
+    end
+  end
+
+  def decide_column(maxsize)
+    if 28 < maxsize && maxsize < 36
+      5
+    else
+      6
+    end
+  end
+
+  def add_end_blank(
+    column,
+    merge_unit_num,
+    first_day_cells,
+    second_day_cells = nil,
+    third_day_cells = nil
+  )
+
+    first_day_cells << "#{@layout_status[:blank]}\s" while first_day_cells.size < column * 7
+    if [2, 3].include?(merge_unit_num)
+      second_day_cells << "#{@layout_status[:blank]}\s" while second_day_cells.size < column * 7
+      if merge_unit_num == 3
+        third_day_cells << "#{@layout_status[:blank]}" while third_day_cells.size < column * 7
+      end
+    end
+
+    case merge_unit_num
+    when 1
+      return first_day_cells
+    when 2
+      return first_day_cells, second_day_cells
+    when 3
+      return first_day_cells, second_day_cells, third_day_cells
+    end
+  end
+
+  def replace_layout_var(all_dates)
+    all_dates.each_with_index do |month, month_index|
+      month[2].each_with_index do |element, day|
+        if element == "blank\s"
+          all_dates[month_index][2][day] = "#{@layout_status[:blank]} "
+        end
+        if element.include?('blank_for_one_char')
+          all_dates[month_index][2][day] = element.gsub(/blank_for_one_char/, @layout_status[:blank_for_one_char].to_s)
+        end
+        if element.include?('blank_for_two_char')
+          all_dates[month_index][2][day] = element.gsub(/blank_for_two_char/, @layout_status[:blank_for_two_char].to_s)
+        end
+        if element.include?('blank_for_three_char')
+          all_dates[month_index][2][day] = element.gsub(/blank_for_three_char/, @layout_status[:blank_for_three_char].to_s)
+        end
+      end
+    end
+  end
+end

--- a/02.calendar/merge_cal.rb
+++ b/02.calendar/merge_cal.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MergeCalender
+class MergeCalendar
   THIS_Y = Date.today.year
   THIS_M = Date.today.mon
   THIS_D = Date.today.day
@@ -12,12 +12,12 @@ class MergeCalender
   end
 
   def merge
-    rendering_calender(@all_dates)
+    rendering_calendar(@all_dates)
   end
 
   private
 
-  def rendering_calender(all_dates)
+  def rendering_calendar(all_dates)
     rendering_string_result = ''
     replaced_all_dates = Marshal.load(Marshal.dump(all_dates))
     replaced_all_dates = replace_layout_var(replaced_all_dates)
@@ -70,11 +70,11 @@ class MergeCalender
       end
       one_month_days_string_result = join_days_string(one_month_day_cells, column)
 
-      <<~CALENDER
+      <<~CALENDAR
         #{@layout_status[:one_caption].call(first_unit[0], first_unit[1])}
         #{@layout_status[:one_week]}
         #{one_month_days_string_result}
-      CALENDER
+      CALENDAR
 
     when 2
       first_day_cells = first_unit[2]
@@ -93,11 +93,11 @@ class MergeCalender
       end
       two_month_days_string_result = join_days_string(two_months_day_cells, column)
 
-      <<~CALENDER
+      <<~CALENDAR
         #{@layout_status[:two_caption].call(first_unit[0], first_unit[1], second_unit[0], second_unit[1])}
         #{@layout_status[:two_weeks]}
         #{two_month_days_string_result}
-      CALENDER
+      CALENDAR
 
     when 3
       first_day_cells = first_unit[2]
@@ -125,33 +125,33 @@ class MergeCalender
       end
       three_month_days_string_result = join_days_string(three_months_day_cells, column)
 
-      <<~CALENDER
+      <<~CALENDAR
         #{@layout_status[:three_caption].call(first_unit[0], first_unit[1], second_unit[0], second_unit[1], third_unit[0], third_unit[1])}
         #{@layout_status[:three_weeks]}
         #{three_month_days_string_result}
-      CALENDER
+      CALENDAR
     end
   end
 
   def join_days_string(day_cells, column)
     case column
     when 6
-      <<~CALENDER
+      <<~CALENDAR
         #{day_cells[0].join}
         #{day_cells[1].join}
         #{day_cells[2].join}
         #{day_cells[3].join}
         #{day_cells[4].join}
         #{day_cells[5].join}
-      CALENDER
+      CALENDAR
     when 5
-      <<~CALENDER
+      <<~CALENDAR
         #{day_cells[0].join}
         #{day_cells[1].join}
         #{day_cells[2].join}
         #{day_cells[3].join}
         #{day_cells[4].join}
-      CALENDER
+      CALENDAR
     end
   end
 

--- a/02.calendar/monthly_calendar.rb
+++ b/02.calendar/monthly_calendar.rb
@@ -2,9 +2,9 @@
 
 require 'date'
 require 'color_echo'
-require './calender_date_unit'
+require './calendar_date_unit'
 
-class MonthlyCalender
+class MonthlyCalendar
   THIS_Y = Date.today.year
   THIS_M = Date.today.mon
   THIS_D = Date.today.day
@@ -18,7 +18,7 @@ class MonthlyCalender
     all_request_about_month = make_request_about_month
     layout_status = make_layout_status
     all_dates = all_request_about_month.map do |date|
-      this_date = CalenderDateUnit.new(date[0], date[1], @request)
+      this_date = CalendarDateUnit.new(date[0], date[1], @request)
       this_date.generate_days
     end
     merge_cal(all_dates, layout_status)
@@ -168,7 +168,7 @@ class MonthlyCalender
   end
 
   def merge_cal(all_dates, layout_status)
-    this_calender = MergeCalender.new(all_dates, layout_status)
-    this_calender.merge
+    this_calendar = MergeCalendar.new(all_dates, layout_status)
+    this_calendar.merge
   end
 end

--- a/02.calendar/monthly_calender.rb
+++ b/02.calendar/monthly_calender.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'color_echo'
+require './calender_date_unit'
+
+class MonthlyCalender
+  THIS_Y = Date.today.year
+  THIS_M = Date.today.mon
+  THIS_D = Date.today.day
+  THIS_W = Date.today.wday
+
+  def initialize(request)
+    @request = request
+  end
+
+  def make_cal
+    all_request_about_month = make_request_about_month
+    layout_status = make_layout_status
+    all_dates = all_request_about_month.map do |date|
+      this_date = CalenderDateUnit.new(date[0], date[1], @request)
+      this_date.generate_days
+    end
+    merge_cal(all_dates, layout_status)
+  end
+
+  private
+
+  def make_request_about_month
+    all_request_about_month_result = []
+    premonth_request = premonth_calc(@request[:basic_month], @request[:basic_year], @request[:pre_month])
+    nextmonth_request = nextmonth_calc(@request[:basic_month], @request[:basic_year], @request[:next_month])
+
+    all_request_about_month_result += premonth_request if !premonth_request.nil?
+    all_request_about_month_result += [[@request[:basic_month], @request[:basic_year]]]
+    all_request_about_month_result += nextmonth_request if !nextmonth_request.nil?
+    all_request_about_month_result
+  end
+
+  def premonth_calc(basic_month, basic_year, pre_num)
+    return if pre_num.nil?
+
+    premonth_request_result = []
+    case
+    when basic_month - pre_num > 0
+      count_pre_month = basic_month - pre_num
+      count_pre_year = basic_year
+    when basic_month - pre_num <= 0
+      count_pre_month = 12 - ((basic_month - pre_num).abs % 12)
+      count_pre_year =  basic_year - ((basic_month - pre_num).abs / 12) - 1
+    end
+
+    while count_pre_year < basic_year
+      while count_pre_month <= 12
+        premonth_request_result << [count_pre_month, count_pre_year]
+        count_pre_month += 1
+      end
+      count_pre_month = 1
+      count_pre_year += 1
+    end
+    while count_pre_month < basic_month
+      premonth_request_result << [count_pre_month, count_pre_year]
+      count_pre_month += 1
+    end
+    premonth_request_result
+  end
+
+  def nextmonth_calc(basic_month, basic_year, next_num)
+    return if next_num.nil?
+
+    next_month = nil
+    next_year = nil
+    nextmonth_request_result = []
+    case
+    when basic_month + next_num <= 12
+      next_month = basic_month + next_num
+      next_year = basic_year
+    when basic_month + next_num > 12
+      next_month = (basic_month + next_num) % 12
+      next_year =  basic_year + (basic_month + next_num) / 12
+    end
+
+    count_next_month = basic_month + 1
+    count_next_year = basic_year
+    while count_next_year < next_year
+      while count_next_month <= 12
+        nextmonth_request_result << [count_next_month, count_next_year]
+        count_next_month += 1
+      end
+      count_next_month = 1
+      count_next_year += 1
+    end
+    while count_next_month <= next_month
+      nextmonth_request_result << [count_next_month, count_next_year]
+      count_next_month += 1
+    end
+    nextmonth_request_result 
+  end
+
+  def make_layout_status
+    layout_status_result = {}
+    case @request[:julius]
+    when true
+      layout_status_result[:margin] = "\s\s\s"
+      layout_status_result[:blank] = "\s\s\s"
+      layout_status_result[:blank_for_one_char] = "\s\s"
+      layout_status_result[:blank_for_two_char] = "\s"
+      layout_status_result[:blank_for_three_char] = ""
+      layout_status_result[:month_column_num] = 2
+      layout_status_result[:one_week] = " 日  月  火  水  木  金  土"
+      layout_status_result[:two_weeks] = " 日  月  火  水  木  金  土   日  月  火  水  木  金  土"
+      layout_status_result[:three_weeks] = " 日  月  火  水  木  金  土   日  月  火  水  木  金  土   日  月  火  水  木  金  土" 
+      one_caption = proc{ |first_month, first_year| "#{"\s" * 10}#{first_month}月\s#{first_year}" }
+      two_caption = proc{ |first_month, first_year, second_month, second_year| "#{"\s" * 10}#{first_month}月 #{first_year}#{"\s" * 21}#{second_month}月\s#{second_year}" }
+      three_caption = proc{ |first_month, first_year, second_month, second_year, third_month, third_year| "#{"\s" * 10}#{first_month}月\s#{first_year}#{"\s" * 7}#{second_month}月\s#{second_year}#{"\s" * 17}#{third_month}月\s#{third_year}" }
+      layout_status_result[:one_caption] = one_caption
+      layout_status_result[:two_caption] = two_caption
+      layout_status_result[:three_caption] = three_caption
+    when false
+      layout_status_result[:margin] = "\s\s"
+      layout_status_result[:blank] = "\s\s"
+      layout_status_result[:blank_for_one_char] = "\s"
+      layout_status_result[:blank_for_two_char] = ''
+      layout_status_result[:month_column_num] = 3
+      layout_status_result[:one_week] = "日 月 火 水 木 金 土"
+      layout_status_result[:two_weeks] = "日 月 火 水 木 金 土  日 月 火 水 木 金 土"
+      layout_status_result[:three_weeks] = "日 月 火 水 木 金 土  日 月 火 水 木 金 土  日 月 火 水 木 金 土"
+      one_caption = proc { |first_month, first_year| "#{"\s" * 7}#{first_month}月\s#{first_year}" }
+      two_caption = proc { |first_month, first_year, second_month, second_year| "#{"\s" * 7}#{first_month}月 #{first_year}#{"\s" * 14}#{second_month}月\s#{second_year}" }
+      three_caption = proc { |first_month, first_year, second_month, second_year, third_month, third_year| "#{"\s" * 7}#{first_month}月\s#{first_year}#{"\s" * 14}#{second_month}月 #{second_year}#{"\s" * 14}#{third_month}月 #{third_year}" }
+      layout_status_result[:one_caption] = one_caption
+      layout_status_result[:two_caption] = two_caption
+      layout_status_result[:three_caption] = three_caption
+    end
+
+    case @request[:year_position]
+    when 'default'
+      header_position = proc { |this_year| '' }
+      layout_status_result[:header_position] = header_position
+    when 'header'
+      case @request[:julius]
+      when true
+        one_caption = proc { |first_month| "#{"\s" * 13}#{first_month}月" }
+        two_caption = proc { |first_month, second_month| "#{"\s" * 13}#{first_month}月#{"\s" * 26}#{second_month}月" }
+        header_position = proc { |this_year| "#{"\s" * 26}#{this_year}年\n" }
+        layout_status_result[:one_caption] = one_caption
+        layout_status_result[:two_caption] = two_caption
+        layout_status_result[:header_position] = header_position
+      when false
+        one_caption = proc { |first_month| "#{"\s" * 7}#{first_month}月" }
+        two_caption = proc { |first_month, second_month| "#{"\s" * 7}#{first_month}月#{"\s" * 14}#{second_month}月" }
+        three_caption = proc { |first_month, second_month, third_month| "#{"\s" * 9}#{first_month}月#{"\s" * 18}#{second_month}月#{"\s" * 18}#{third_month}月" }
+        header_position = proc { |this_year| "#{"\s" * 28}#{this_year}年\n" }
+        layout_status_result[:one_caption] = one_caption
+        layout_status_result[:two_caption] = two_caption
+        layout_status_result[:three_caption] = three_caption
+        layout_status_result[:header_position] = header_position
+      end
+    end
+
+    case @request[:highligth]
+    when true
+      layout_status_result[:highligth] = true
+    when false
+      layout_status_result[:highligth] = false
+    end
+    layout_status_result
+  end
+
+  def merge_cal(all_dates, layout_status)
+    this_calender = MergeCalender.new(all_dates, layout_status)
+    this_calender.merge
+  end
+end

--- a/02.calendar/optparse_conditions.rb
+++ b/02.calendar/optparse_conditions.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module OptparseConditions
+  def opt_has_two_numbers?(argv, opt_index_num)
+    (/^\d+$/ === argv[opt_index_num + 1].to_s && /^\d+$/ === argv[opt_index_num.to_i + 2].to_s)
+  end
+
+  def opt_has_one_number?(argv, opt_index_num)
+    (/^\d+$/ === argv[opt_index_num + 1].to_s)
+  end
+
+  def correct_month?(argv, index_num)
+    argv[index_num].to_i.between?(1, 12)
+  end
+
+  def correct_year?(argv, index_num)
+    argv[index_num].to_i.between?(1, 9999)
+  end
+
+  def opt_has_no_num?(argv, opt_index_num)
+    /^\D+$/ === argv[opt_index_num + 1] || argv[opt_index_num + 1].nil?
+  end
+
+  def some_opt_after_this_opt?(argv, index_num)
+    /^\D+$/ === argv[index_num + 1]
+  end
+
+  def argv_has_conflicting_opt?(argv, conflicting_opt_list)
+    conflicting_opt = argv & conflicting_opt_list
+    !conflicting_opt.empty?
+  end
+end

--- a/02.calendar/optparse_run.rb
+++ b/02.calendar/optparse_run.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'date'
+require './optparse_conditions'
+
+class OptparseRun
+  include OptparseConditions
+
+  THIS_Y = Date.today.year
+  THIS_M = Date.today.mon
+  THIS_D = Date.today.day
+  THIS_W = Date.today.wday
+
+  def initialize(keys)
+    @keys = keys
+    @keys_result = keys
+  end
+
+  def optparse_run
+    argv_parser = OptionParser.new
+    argv = Marshal.load(Marshal.dump(ARGV))
+
+    begin
+      argv_parser_on_y(argv_parser, argv)
+      argv_parser_on_m(argv_parser, argv)
+      argv_parser_on_3(argv_parser, argv)
+      argv_parser_on_A(argv_parser, argv)
+      argv_parser_on_B(argv_parser, argv)
+      argv_parser_on_j(argv_parser, argv)
+      argv_parser_on_h(argv_parser, argv)
+
+      argv_parser.parse(argv)
+
+      argv_parser_on_no_opt(argv)
+    rescue NoMethodError
+      puts 'エラークラス: NoMethodError'
+      puts 'そのオプションは無効です'
+      exit
+    rescue OptionParser::InvalidOption
+      puts 'エラークラス: OptionParser::InvalidOption'
+      puts 'そのオプションは無効です'
+      exit
+    rescue OptionParser::MissingArgument
+      puts 'エラークラス: OptionParser::MissingArgument'
+      puts 'オプションに引数を与えてください'
+      exit
+    rescue
+      puts 'エラークラス: 不明'
+      puts 'そのオプションは無効です'
+      exit
+    end
+    @keys_result
+  end
+
+  private
+
+  def argv_parser_on_y(argv_parser, argv)
+    argv_parser.on('-y [VAL]') do |v|
+      index = argv.find_index('-y')
+      case
+      when opt_has_one_number?(argv, index) && !correct_year?(argv, index + 1)
+        puts '年は1から9999の間で入力してください'
+        exit
+      when opt_has_two_numbers?(argv, index)
+        puts '月を入力することはできません'
+        exit
+      end
+
+      case
+      when opt_has_one_number?(argv, index) && correct_year?(argv, index + 1)
+        @keys_result[:next_month] = 11
+        @keys_result[:basic_month] = 1
+        @keys_result[:basic_year] = v.to_i
+      when opt_has_no_num?(argv, index)
+        @keys_result[:next_month] = 11
+        @keys_result[:basic_month] = 1
+        @keys_result[:basic_year] = THIS_Y
+      end
+      @keys_result[:year_position] = 'header'
+    end
+  end
+
+  def argv_parser_on_m(argv_parser, argv)
+    argv_parser.on('-m VAL') do |v|
+      index = argv.find_index('-m')
+      case
+      when some_opt_after_this_opt?(argv, index) || opt_has_no_num?(argv, index)
+        puts '-mオプションの直後には月を入力してください'
+        exit
+      when opt_has_one_number?(argv, index) && !correct_month?(argv, index + 1)
+        puts '月は1から12の間で入力してください'
+        exit
+      when opt_has_two_numbers?(argv, index) && !correct_year?(argv, index + 2)
+        puts '年は1から9999の間で入力してください'
+        exit
+      end
+
+      case
+      when opt_has_two_numbers?(argv, index) && correct_month?(argv, index + 1) && correct_year?(argv, index + 2)
+        @keys_result[:basic_month] = argv[index + 1].to_i
+        @keys_result[:basic_year] = argv[index + 2].to_i
+        argv.delete_at(index + 2)
+        argv.delete_at(index + 1)
+        argv.delete_at(index)
+      when opt_has_one_number?(argv, index) && correct_month?(argv, index + 1)
+        @keys_result[:basic_month] = argv[index + 1].to_i
+        @keys_result[:basic_year] = THIS_Y
+        argv.delete_at(index + 1)
+        argv.delete_at(index)
+      end
+    end
+  end
+
+  def argv_parser_on_3(argv_parser, argv)
+    argv_parser.on('-3') do |v|
+      index = argv.find_index('-3')
+      @conflicting_opt_list = ['-y', '-A', '-B']
+      @keys_result[:pre_month] = 1
+      @keys_result[:next_month] = 1
+
+      case
+      when opt_has_two_numbers?(argv, index) && !correct_month?(argv, index + 1)
+        puts '月は1から12の間で入力してください'
+        exit
+      when argv_has_conflicting_opt?(argv, @conflicting_opt_list)
+        puts 'これらのオプションは同時に使えません'
+        exit
+      when opt_has_one_number?(argv, index) && !opt_has_two_numbers?(argv, index)
+        puts '年を入力してください'
+        exit
+      end
+
+      case
+      when opt_has_two_numbers?(argv, index) && correct_month?(argv, index + 1) && correct_year?(argv, index + 2)
+        @keys_result[:basic_month] = argv[index + 1].to_i
+        @keys_result[:basic_year] = argv[index + 2].to_i
+        @keys_result[:pre_month] = 1
+        @keys_result[:next_month] = 1
+        argv.delete_at(index + 2)
+        argv.delete_at(index + 1)
+        argv.delete_at(index)
+      when opt_has_no_num?(argv, index)
+        @keys_result[:basic_month] = THIS_M
+        @keys_result[:basic_year] = THIS_Y
+        @keys_result[:pre_month] = 1
+        @keys_result[:next_month] = 1
+        argv.delete_at(index)
+      end
+    end
+  end
+
+  def argv_parser_on_A(argv_parser, argv)
+    argv_parser.on('-A VAL') do |v|
+      index = argv.find_index('-A')
+      case
+      when !opt_has_one_number?(argv, index)
+        puts 'オプションの後ろに何ヶ月先まで表示するか入力してください'
+        exit
+      end
+
+      case
+      when opt_has_one_number?(argv, index)
+        @keys_result[:next_month] = v.to_i
+        argv.delete_at(index + 1)
+        argv.delete_at(index)
+      end
+      @keys_result[:next_month] = v.to_i
+    end
+  end
+
+  def argv_parser_on_B(argv_parser, argv)
+    argv_parser.on('-B VAL') do |v|
+      index = argv.find_index('-B')
+      case
+      when !opt_has_one_number?(argv, index)
+        puts 'オプションの後ろに何ヶ月前まで表示するか入力してください'
+        exit
+      end
+
+      case
+      when opt_has_one_number?(argv, index)
+        @keys_result[:pre_month] = v.to_i
+        argv.delete_at(index + 1)
+        argv.delete_at(index)
+      end
+      @keys_result[:pre_month] = v.to_i
+    end
+  end
+
+  def argv_parser_on_j(argv_parser, argv)
+    argv_parser.on('-j') do | v |
+      index = argv.find_index('-j')
+      @keys_result[:julius] = true
+      argv.delete_at(index)
+    end
+  end
+
+  def argv_parser_on_h(argv_parser, argv)
+    argv_parser.on('-h') do |v|
+      index = argv.find_index('-h')
+      @keys_result[:highligth] = false
+      argv.delete_at(index)
+    end
+  end
+
+  def argv_parser_on_no_opt(argv)
+    case
+    when argv.size == 2 && /\d{1,2}/ === argv[0] && /\d{1,4}/ === argv[1] && correct_month?(argv, 0) && !correct_year?(argv, 1)
+      puts '年は1から9999の間で入力してください'
+      exit
+    when argv.size == 2 && /\d{1,2}/ === argv[0] && /\d{1,4}/ === argv[1] && !correct_month?(argv, 0) && correct_year?(argv, 1)
+      puts '月は1から12の間で入力してください'
+      exit
+    when argv.size == 1 && /\d{1,4}/ === argv[0] && !correct_year?(argv, 0)
+      puts '年は1から9999の間で入力してください'
+      exit
+    end
+
+    case
+    when argv.size == 2 && /\d{1,2}/ === argv[0] && /\d{1,4}/ === argv[1] && correct_month?(argv, 0) && correct_year?(argv, 1)
+      @keys_result[:basic_month] = argv[0].to_i
+      @keys_result[:basic_year] = argv[1].to_i
+    when argv.size == 1 && /\d{1,4}/ === argv[0] && correct_year?(argv, 0)
+      @keys_result[:basic_year] = argv[0].to_i
+    end
+  end
+end

--- a/02.calendar/rubycal.rb
+++ b/02.calendar/rubycal.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require './rubycal_factory'
+def do_rubycal
+  order = RubyCalFactory.new
+  puts order.run
+end
+
+do_rubycal

--- a/02.calendar/rubycal_factory.rb
+++ b/02.calendar/rubycal_factory.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require './make_request'
+require './monthly_calender'
+require './merge_cal'
+
+class RubyCalFactory
+  def run
+    make_result
+  end
+
+  private
+  
+  def make_result
+    request = make_request
+    make_cal(request)
+  end
+
+  def make_request
+    MakeRequest.new.make_request
+  end
+
+  def make_cal(request)
+    calender = MonthlyCalender.new(request)
+    calender.make_cal
+  end
+end

--- a/02.calendar/rubycal_factory.rb
+++ b/02.calendar/rubycal_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require './make_request'
-require './monthly_calender'
+require './monthly_calendar'
 require './merge_cal'
 
 class RubyCalFactory
@@ -21,7 +21,7 @@ class RubyCalFactory
   end
 
   def make_cal(request)
-    calender = MonthlyCalender.new(request)
-    calender.make_cal
+    calendar = MonthlyCalendar.new(request)
+    calendar.make_cal
   end
 end


### PR DESCRIPTION
カレンダープログラムを作成しました。
レビューよろしくお願いします！🙇‍♂️

# レビューにあたって

全体を眺めるときにはこの図が参考になるかと思います。
![RubyCalender](https://user-images.githubusercontent.com/77069305/115687689-654e0a80-a395-11eb-8c68-d6b84bad584e.png)

また、多くのオプションを実行できるようにしたので複雑なクラスがあります。
特に```MonthlyCalendar``` ```MergeCalendar``` ```CalendarDateUnit```は読みづらいかもしれないので、ここで補足しておきます。

## MonthlyCalendarクラス
オプションの内容を元に、実際にカレンダーを作るための指示をするクラスです。
必要な年月の配列つくり、具体的な日付をCalendarDateUnitクラスから得て、MergeCalendarクラスで一つの文字列にします。

### make_request_about_monthメソッド
このメソッドでは実際に何年何月のカレンダーを作るか決めます。
例えば```-A 2```オプションが指定されると、```@request[:next_month]```に```2```が入ります。
```2```は2ヶ月先までのカレンダーを表示することになりますが、年を跨ぐ場合とそうでない場合があります。
```
nextmonth_request = nextmonth_calc(@request[:basic_month], @request[:basic_year], @request[:next_month])
```
では同じクラス内のnextmonth_calcメソッドを使って具体的に何年何月が必要かどうか計算して```[[5, 2021], [6, 2021]]```という配列を作ります。
```-A 2```オプションであればこのメソッドは、必要な年月の配列を最後に結合して、```[[4, 2021], [5, 2021], [6, 2021]]```を返します。


## CalendarDateUnitクラス
ひと月ぶんの日付を生成するクラスです。

### generate_one_month_daysメソッド
1日から月末までの日付を配列にします。

### add_blankメソッド
レイアウトに必要な日付同士のマージンを取ったり、1日より手前や月末日よりあとの空白を作ります。
-jコマンドによって必要なマージンが変わりますが、ここではマージンを変数で表しておいてMergeCalendarクラスで半角スペースに置き換えます。
その際、```layout_status```ハッシュを参照します。
また、-hオプションにはここで対応します。


## MergeCalendarクラス
全ての日付を結合して、実際に表示するための文字列を作るクラスです。

### rendering_calendarメソッド
まずreplace_layout_varメソッドにて、```layout_status```ハッシュを使って変数で置き換えていたマージンたちを展開して、実際の空白に置き換えます。
次の```while```部分では、カレンダーを何列表示にするかによって場合分けして月ごとに一行の塊にしていきます。
![merge_cal_rb_—_Untitled__Workspace_](https://user-images.githubusercontent.com/77069305/115692958-6b92b580-a39a-11eb-900f-cba8b3655d1d.png)
```-j```コマンドが効いていれば、デフォルトで2列なので画像のようなレイアウトになります。
また、```-j```コマンドが効いていてもいなくても、端数の月があれば2列表示、1列表示がでてきます。
![スクリーンショット 2021-04-22 18 57 09](https://user-images.githubusercontent.com/77069305/115695247-97169f80-a39c-11eb-8542-f3e37b2ce317.png)
それも合わせてこの```while```部分で処理しています。

### merge_date_unitメソッド
カレンダーの日付は下の画像のように、横一列のStringに改行を挟んで作っています。
![merge_cal_rb_—_Untitled__Workspace_](https://user-images.githubusercontent.com/77069305/115693975-66823600-a39b-11eb-8a3b-2a72850e14cf.png)
カレンダーが1列なのか、2列なのか、3列なのかで```case```で条件分岐させたあと
```
      three_months_day_cells.map.each_with_index do |grid, index|
        grid[0..6] = first_day_cells[index * 7..index * 7 + 6]
        grid[7..13] = second_day_cells[index * 7..index * 7 + 6]
        grid[14..20] = third_day_cells[index * 7..index * 7 + 6]
        grid.insert(14, "\s")
        grid.insert(7, "\s")
      end
```
グリットをイメージした二次配列にそれぞれのカレンダーを分割し当てはめています。

### add_end_blankメソッド
カレンダーの最後の行は、組み合わせる月の数や、月の日数によって空白の数が変化します。
![merge_cal_rb_—_Untitled__Workspace_](https://user-images.githubusercontent.com/77069305/115694588-f7f1a800-a39b-11eb-96cb-61006a77cfa7.png)
このメソッドでは結合するカレンダーに合わせて空白を配列に追加しています。

# 実行可能なコマンドについて
以下のコマンドが使えます。```[  ]```内の引数は省略可能です。
* -y [year]
* -m month
* -3
* -A month
* -B month
* -j
* -h

また、オプション指定なしだと、年月が指定できます。
* [[month]year]

## 組み合わせについて
calコマンドと異なる点がいくつかあります。

### calはできなくてrubycalでできること
* ```4 2021 -h```　---年月を指定した後に別のオプションを入力する
* ```2 2020 -A 2```　---```-A``` ```-B```に対して年月を手前に入力する
* ```-B 1 5```　---（```1```は```-B```のオプションで、```5```は月の指定）

年月指定をオプション内のどこでも行えるようにしたので
```-A 1 -B 5 5 2021 -j -h```といった複雑なオプションを実行することができるようになりました。

### 逆にrubycalでできないこと
* ```-hj``` のようなオプションの接続