### PR TITLE
add: bowling

### DIFF
--- a/03.bowling/bowling.rb
+++ b/03.bowling/bowling.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+def calculate_bowling_score(frames)
+  total_score = 0
+  frame_index = 0
+
+  10.times do |_frame|
+    if frames[frame_index] == 10
+      total_score += 10 + frames[frame_index + 1] + frames[frame_index + 2]
+      frame_index += 1
+    elsif frames[frame_index] + frames[frame_index + 1] == 10
+      total_score += 10 + frames[frame_index + 2]
+      frame_index += 2
+    else
+      total_score += frames[frame_index] + frames[frame_index + 1]
+      frame_index += 2
+    end
+  end
+
+  total_score
+end
+
+shots = ARGV[0].split(',').map do |s|
+  if s == 'X'
+    10
+  else
+    s.to_i
+  end
+end
+puts calculate_bowling_score(shots)


### PR DESCRIPTION
## 実行結果
ruby-practices/03.bowling on  bowling [✘?] via 💎 v3.2.2 on ☁️  (ap-northeast-1) took 15s 
❯ ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,6,4,5
139

ruby-practices/03.bowling on  bowling [✘?] via 💎 v3.2.2 on ☁️  (ap-northeast-1) took 15s 
❯ ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,X,X,X
164

ruby-practices/03.bowling on  bowling [✘?] via 💎 v3.2.2 on ☁️  (ap-northeast-1) took 15s 
 ./bowling.rb 0,10,1,5,0,0,0,0,X,X,X,5,1,8,1,0,4
107

ruby-practices/03.bowling on  bowling [✘?] via 💎 v3.2.2 on ☁️  (ap-northeast-1) 
❯ ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,X,0,0
134

ruby-practices/03.bowling on  bowling [✘?] via 💎 v3.2.2 on ☁️  (ap-northeast-1) 
❯ ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,X,1,8
144

ruby-practices/03.bowling on  bowling [✘?] via 💎 v3.2.2 on ☁️  (ap-northeast-1) 
❯ ./bowling.rb X,X,X,X,X,X,X,X,X,X,X,X 
300

ruby-practices/03.bowling on  bowling [✘?] via 💎 v3.2.2 on ☁️  (ap-northeast-1) 
❯ ./bowling.rb X,X,X,X,X,X,X,X,X,X,X,2
292

ruby-practices/03.bowling on  bowling [✘?] via 💎 v3.2.2 on ☁️  (ap-northeast-1) 
❯ ./bowling.rb X,0,0,X,0,0,X,0,0,X,0,0,X,0,0 
50

## rubocopの実行結果

![スクリーンショット 0006-01-22 11 56 40](https://github.com/fjordllc/ruby-practices/assets/96639213/7063f9ff-291e-411f-82eb-320273072aa9)


