### PR TITLE
calender command

### DIFF
--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -6,12 +6,12 @@ month = Date.today.month
 year = Date.today.year
 
 OptionParser.new do |opt|
-  opt.on("-m MONTH", "--month MONTH", "受け取った月") do |m|
-    month = m.to_i
+  opt.on("-m MONTH", "--month MONTH", Integer, "受け取った月") do |m|
+    month = m
   end
 
-  opt.on("-y YEAR", "--year YEAR", "年を指定") do |y|
-    year = y.to_i
+  opt.on("-y YEAR", "--year YEAR", Integer, "年を指定") do |y|
+    year = y
   end
 end.parse!
 
@@ -44,3 +44,5 @@ end
     print "\n"
   end
 end
+
+puts

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+require "optparse"
+require "date"
+
+month = Date.today.month
+year = Date.today.year
+
+OptionParser.new do |opt|
+  opt.on("-m MONTH", "--month MONTH", "受け取った月") do |m|
+    month = m.to_i
+  end
+
+  opt.on("-y YEAR", "--year YEAR", "年を指定") do |y|
+    year = y.to_i
+  end
+end.parse!
+
+abort "1〜12の月を指定してください" unless (1..12).include?(month)
+abort "1970〜2100の年を指定してください" unless (1970..2100).include?(year)
+
+first_day = Date.new(year, month, 1)
+first_wday = first_day.wday
+
+last_day = Date.new(year, month, -1)
+days_in_month = last_day.mday
+
+title = "#{month}月 #{year}".center(20)
+week_header = "日 月 火 水 木 金 土 "
+puts title.center(week_header.length)
+puts week_header
+
+first_wday.times do
+  print "   "
+end
+
+(1..days_in_month).each do |n|
+  if n < 10
+    print " #{n} "
+  else
+    print "#{n} "
+  end
+
+  if (first_wday + n) % 7 == 0
+    print "\n"
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * コマンドラインで月・年を指定してフォーマット済みの月間カレンダーを表示するツールを追加しました（既定で当月を表示）。
  * 短縮オプションで月と年を指定可能。入力範囲は妥当性チェックされ、範囲外は日本語のエラーメッセージで通知されます。
  * 出力は日本語の曜日ヘッダ（「日 月 火 水 木 金 土」）と中央揃えの年月表示に対応しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->