### PR TITLE
lsコマンドに-aオプションを追加

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -14,14 +14,18 @@ end
 
 def display_files(files)
   rows = files.size.ceildiv(COLUMNS)
-  width = files.map { |f| f.encode("EUC-JP").bytesize }.max + 2
+  
+  max_length = 0
+  files.each do |file|
+    max_length = file.size if file.size > max_length
+  end
+  width = max_length + 2
   nested_files = files.each_slice(rows).to_a
   nested_files.map { |column| column.fill(nil, column.size...rows) }
   nested_files.transpose.each do |row|
     row.each do |file|
       next if file.nil?
-      padding_size = width - file.encode("EUC-JP").bytesize
-      print file + (" " * padding_size) if file
+      print file.ljust(width) if file
     end
     puts
   end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,25 +1,29 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+COLUMNS = 3
+
 def main
   files = fetch_files
   display_files(files)
 end
 
 def fetch_files
-  Dir.glob('*').sort
+  Dir.glob('*')
 end
 
 def display_files(files)
-  columns = 3
-  rows = (files.size.to_f / columns).ceil
+  rows = files.size.ceildiv(COLUMNS)
+  width = files.map { |f| f.encode("EUC-JP").bytesize }.max + 2
   nested_files = files.each_slice(rows).to_a
-  nested_files.map! { |column| column.fill(nil, column.size...rows) }
+  nested_files.map { |column| column.fill(nil, column.size...rows) }
   nested_files.transpose.each do |row|
     row.each do |file|
-      print file.ljust(16) if file
+      next if file.nil?
+      padding_size = width - file.encode("EUC-JP").bytesize
+      print file + (" " * padding_size) if file
     end
-    puts ''
+    puts
   end
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,15 +1,26 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'optparse'
+
 COLUMNS = 3
 
 def main
-  files = fetch_files
+  options = {}
+  opt = OptionParser.new
+  opt.on('-a') { |v| options[:a] = v }
+  opt.parse!(ARGV)
+
+  files = fetch_files(all: options[:a])
   display_files(files)
 end
 
-def fetch_files
-  Dir.glob('*')
+def fetch_files(all: false)
+  if all
+    Dir.glob('*', File::FNM_DOTMATCH).sort
+  else
+    Dir.glob('*').sort
+  end
 end
 
 def display_files(files)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -13,15 +13,13 @@ def fetch_files
 end
 
 def display_files(files)
+  return if files.empty?
+
   rows = files.size.ceildiv(COLUMNS)
-  
-  max_length = 0
-  files.each do |file|
-    max_length = file.size if file.size > max_length
-  end
-  width = max_length + 2
+
+  width = files.map(&:size).max + 2
   nested_files = files.each_slice(rows).to_a
-  nested_files.map { |column| column.fill(nil, column.size...rows) }
+  nested_files.each { |column| column.fill(nil, column.size...rows) }
   nested_files.transpose.each do |row|
     row.each do |file|
       next if file.nil?

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+def main
+  files = fetch_files
+  display_files(files)
+end
+
+def fetch_files
+  Dir.glob('*').sort
+end
+
+def display_files(files)
+  columns = 3
+  rows = (files.size.to_f / columns).ceil
+  nested_files = files.each_slice(rows).to_a
+  nested_files.map! { |column| column.fill(nil, column.size...rows) }
+  nested_files.transpose.each do |row|
+    row.each do |file|
+      print file.ljust(16) if file
+    end
+    puts ''
+  end
+end
+
+main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -23,7 +23,7 @@ def display_files(files)
   nested_files.transpose.each do |row|
     row.each do |file|
       next if file.nil?
-      print file.ljust(width) if file
+      print file.ljust(width)
     end
     puts
   end


### PR DESCRIPTION
lsコマンドに-aオプションを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **ファイルリスト表示機能を追加**
  * ディレクトリ内のファイルを複数列で見やすく表示
  * `-a` オプションで隠しファイルも含めて表示可能
  * ファイル名順にソートして表示

<!-- end of auto-generated comment: release notes by coderabbit.ai -->