### PR TITLE
ls -rコマンドの実装

### DIFF
--- a/04.ls/ls
+++ b/04.ls/ls
@@ -7,7 +7,6 @@ def fetch_files
   Dir.glob('*').sort
 end
 
-# 行列を作成する関数
 def make_matrix(files, row, col)
   matrix = Array.new(row) { Array.new(col) }
 
@@ -20,7 +19,6 @@ def make_matrix(files, row, col)
   matrix
 end
 
-# 行列を表示する関数
 def print_matrix(matrix)
   # 最大文字数を取得（列揃えのため）
   max_length = matrix.flatten.compact.map(&:length).max || 0
@@ -36,7 +34,6 @@ def print_matrix(matrix)
   end
 end
 
-# 実行
 files = fetch_files
 row = (files.length.to_f / COL).ceil
 

--- a/04.ls/ls
+++ b/04.ls/ls
@@ -11,7 +11,7 @@ def make_matrix(files, row, col)
   matrix = Array.new(row) { Array.new(col) }
 
   (0...files.length).each do |i|
-    c, r = i.divmod(row) # ② divmodで置き換え
+    c, r = i.divmod(row) 
 
     matrix[r][c] = files[i] if c < col
   end

--- a/04.ls/ls
+++ b/04.ls/ls
@@ -1,17 +1,12 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# 定数（④）
-SIZE = 3
-
-# ファイルを取得する関数（③）
+# ファイルを取得する関数
 def fetch_files
-  Dir.entries('.')
-     .reject { |file| file.start_with?('.') }
-     .sort
+  Dir.glob('*').sort
 end
 
-# 行列を作成する関数（①②）
+# 行列を作成する関数
 def make_matrix(files, row, col)
   matrix = Array.new(row) { Array.new(col) }
 
@@ -24,7 +19,7 @@ def make_matrix(files, row, col)
   matrix
 end
 
-# 行列を表示する関数（⑤）
+# 行列を表示する関数
 def print_matrix(matrix)
   # 最大文字数を取得（列揃えのため）
   max_length = matrix.flatten.compact.map(&:length).max || 0
@@ -42,5 +37,10 @@ end
 
 # 実行
 files = fetch_files
-matrix = make_matrix(files, SIZE, SIZE)
+
+# 列数と行数を計算
+col = 3
+row = (files.length.to_f / col).ceil
+
+matrix = make_matrix(files, row, col)
 print_matrix(matrix)

--- a/04.ls/ls
+++ b/04.ls/ls
@@ -11,7 +11,7 @@ def make_matrix(files, row, col)
   matrix = Array.new(row) { Array.new(col) }
 
   (0...files.length).each do |i|
-    c, r = i.divmod(row) 
+    c, r = i.divmod(row)
 
     matrix[r][c] = files[i] if c < col
   end
@@ -20,14 +20,13 @@ def make_matrix(files, row, col)
 end
 
 def print_matrix(matrix)
-  # 最大文字数を取得（列揃えのため）
   max_length = matrix.flatten.compact.map(&:length).max || 0
 
   matrix.each do |row|
     line = row.map do |file|
       next '' if file.nil?
 
-      file.ljust(max_length) # 左寄せで幅を揃える
+      file.ljust(max_length)
     end.join('   ')
 
     puts line

--- a/04.ls/ls
+++ b/04.ls/ls
@@ -14,7 +14,6 @@ end.parse!
 def fetch_files(all: false)
   flags = all ? File::FNM_DOTMATCH : 0
   Dir.glob('*', flags)
-     .reject { |file| %w[. ..].include?(file) }
 end
 
 def make_matrix(files, row, col)

--- a/04.ls/ls
+++ b/04.ls/ls
@@ -1,11 +1,21 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'optparse'
 COL = 3
 
-def fetch_files(args)
-  if args.include?('-a')
-    Dir.glob('{*,.*}').sort
+options = { all: false }
+OptionParser.new do |opts|
+  opts.on('-a') do
+    options[:all] = true
+  end
+end.parse!
+
+def fetch_files(all: false)
+  if all
+    Dir.glob('*', File::FNM_DOTMATCH)
+       .reject { |file| %w[. ..].include?(file) }
+       .sort
   else
     Dir.glob('*').sort
   end
@@ -37,7 +47,7 @@ def print_matrix(matrix)
   end
 end
 
-files = fetch_files(ARGV)
+files = fetch_files(all: options[:all])
 row = (files.length.to_f / COL).ceil
 matrix = make_matrix(files, row, COL)
 print_matrix(matrix)

--- a/04.ls/ls
+++ b/04.ls/ls
@@ -4,16 +4,15 @@
 require 'optparse'
 COL = 3
 
-options = { all: false }
+options = { reverse: false }
 OptionParser.new do |opts|
-  opts.on('-a') do
-    options[:all] = true
+  opts.on('-r') do
+    options[:reverse] = true
   end
 end.parse!
 
-def fetch_files(all: false)
-  flags = all ? File::FNM_DOTMATCH : 0
-  Dir.glob('*', flags)
+def fetch_files
+  Dir.glob('*')
 end
 
 def make_matrix(files, row, col)
@@ -42,7 +41,8 @@ def print_matrix(matrix)
   end
 end
 
-files = fetch_files(all: options[:all])
+files = fetch_files
+files.reverse! if options[:reverse]
 row = (files.length.to_f / COL).ceil
 matrix = make_matrix(files, row, COL)
 print_matrix(matrix)

--- a/04.ls/ls
+++ b/04.ls/ls
@@ -3,8 +3,12 @@
 
 COL = 3
 
-def fetch_files
-  Dir.glob('*').sort
+def fetch_files(args)
+  if args.include?('-a')
+    Dir.glob('{*,.*}').sort
+  else
+    Dir.glob('*').sort
+  end
 end
 
 def make_matrix(files, row, col)
@@ -33,8 +37,7 @@ def print_matrix(matrix)
   end
 end
 
-files = fetch_files
+files = fetch_files(ARGV)
 row = (files.length.to_f / COL).ceil
-
 matrix = make_matrix(files, row, COL)
 print_matrix(matrix)

--- a/04.ls/ls
+++ b/04.ls/ls
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+# require 'debug'
+# ファイルを取得する関数
+def fetch_files
+  files = Dir.entries('.') # カレントディレクトリのファイルを取得
+  new_files = [] 
+
+  files.each do |file|
+    if !file.start_with?('.') # ドットで始まるファイルは除外
+      new_files << file
+    end
+  end
+
+  new_files.sort # ファイルをアルファベット順にソート
+end
+
+# 行列を作成する関数
+def make_matrix(files, row, col)
+  matrix = Array.new(row) { Array.new(col) }
+
+  i = 0
+  while i < files.length # ファイルの数だけループ
+    r = i % row
+    c = i / row
+
+    if c < col
+      matrix[r][c] = files[i] # 行列にファイルを配置
+    end
+  
+    i += 1
+  end
+  
+  matrix # 行列を返す
+end
+
+# 行列を表示する関数
+def print_matrix(matrix)
+  matrix.each do |row| # 行ごとにループ
+    line = ""
+
+    row.each do |file| # 列ごとにループ
+      if file != nil
+        line = line + file + "   " # ファイル名をスペースで区切って表示
+      end
+    end
+    puts line
+  end
+end
+
+# 関数実行
+files = fetch_files
+matrix = make_matrix(files, 3, 3) # 3行3列の行列を作成
+print_matrix(matrix)

--- a/04.ls/ls
+++ b/04.ls/ls
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# ファイルを取得する関数
+COL = 3
+
 def fetch_files
   Dir.glob('*').sort
 end
@@ -37,10 +38,7 @@ end
 
 # 実行
 files = fetch_files
+row = (files.length.to_f / COL).ceil
 
-# 列数と行数を計算
-col = 3
-row = (files.length.to_f / col).ceil
-
-matrix = make_matrix(files, row, col)
+matrix = make_matrix(files, row, COL)
 print_matrix(matrix)

--- a/04.ls/ls
+++ b/04.ls/ls
@@ -1,53 +1,46 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# require 'debug'
-# ファイルを取得する関数
+# 定数（④）
+SIZE = 3
+
+# ファイルを取得する関数（③）
 def fetch_files
-  files = Dir.entries('.') # カレントディレクトリのファイルを取得
-  new_files = []
-
-  files.each do |file|
-    new_files << file if !file.start_with?('.') # ドットで始まるファイルは除外
-  end
-
-  new_files.sort # ファイルをアルファベット順にソート
+  Dir.entries('.')
+     .reject { |file| file.start_with?('.') }
+     .sort
 end
 
-# 行列を作成する関数
+# 行列を作成する関数（①②）
 def make_matrix(files, row, col)
   matrix = Array.new(row) { Array.new(col) }
 
-  i = 0
-  while i < files.length # ファイルの数だけループ
-    r = i % row
-    c = i / row
+  (0...files.length).each do |i|
+    c, r = i.divmod(row) # ② divmodで置き換え
 
-    if c < col
-      matrix[r][c] = files[i] # 行列にファイルを配置
-    end
-
-    i += 1
+    matrix[r][c] = files[i] if c < col
   end
 
-  matrix # 行列を返す
+  matrix
 end
 
-# 行列を表示する関数
+# 行列を表示する関数（⑤）
 def print_matrix(matrix)
-  matrix.each do |row| # 行ごとにループ
-    line = ''
+  # 最大文字数を取得（列揃えのため）
+  max_length = matrix.flatten.compact.map(&:length).max || 0
 
-    row.each do |file| # 列ごとにループ
-      if !file.nil?
-        line = "#{line}#{file}   " # ファイル名をスペースで区切って表示
-      end
-    end
+  matrix.each do |row|
+    line = row.map do |file|
+      next '' if file.nil?
+
+      file.ljust(max_length) # 左寄せで幅を揃える
+    end.join('   ')
+
     puts line
   end
 end
 
-# 関数実行
+# 実行
 files = fetch_files
-matrix = make_matrix(files, 3, 3) # 3行3列の行列を作成
+matrix = make_matrix(files, SIZE, SIZE)
 print_matrix(matrix)

--- a/04.ls/ls
+++ b/04.ls/ls
@@ -12,13 +12,9 @@ OptionParser.new do |opts|
 end.parse!
 
 def fetch_files(all: false)
-  if all
-    Dir.glob('*', File::FNM_DOTMATCH)
-       .reject { |file| %w[. ..].include?(file) }
-       .sort
-  else
-    Dir.glob('*').sort
-  end
+  flags = all ? File::FNM_DOTMATCH : 0
+  Dir.glob('*', flags)
+     .reject { |file| %w[. ..].include?(file) }
 end
 
 def make_matrix(files, row, col)

--- a/04.ls/ls
+++ b/04.ls/ls
@@ -1,14 +1,14 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 # require 'debug'
 # ファイルを取得する関数
 def fetch_files
   files = Dir.entries('.') # カレントディレクトリのファイルを取得
-  new_files = [] 
+  new_files = []
 
   files.each do |file|
-    if !file.start_with?('.') # ドットで始まるファイルは除外
-      new_files << file
-    end
+    new_files << file if !file.start_with?('.') # ドットで始まるファイルは除外
   end
 
   new_files.sort # ファイルをアルファベット順にソート
@@ -26,21 +26,21 @@ def make_matrix(files, row, col)
     if c < col
       matrix[r][c] = files[i] # 行列にファイルを配置
     end
-  
+
     i += 1
   end
-  
+
   matrix # 行列を返す
 end
 
 # 行列を表示する関数
 def print_matrix(matrix)
   matrix.each do |row| # 行ごとにループ
-    line = ""
+    line = ''
 
     row.each do |file| # 列ごとにループ
-      if file != nil
-        line = line + file + "   " # ファイル名をスペースで区切って表示
+      if !file.nil?
+        line = "#{line}#{file}   " # ファイル名をスペースで区切って表示
       end
     end
     puts line


### PR DESCRIPTION
### 背景
FBCプラクティス（lsコマンドを作る3）を実施しました。

### ソースコード補足
「-a」コマンドを作成したときに実装した
OptionParser機能を残し、「-r」を検出してソートさせる仕組みとして実装しました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * カレントディレクトリ内のファイル一覧を、3列の見やすい形式で表示できるようになりました。
  * `-r` オプションにより、一覧の表示順を反転できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->