### PR TITLE
lsコマンドを作る1

### DIFF
--- a/04.ls/lib/ls.rb
+++ b/04.ls/lib/ls.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+COLUMN_COUNT = 3
+
+def fetch_files
+  Dir.glob('*').sort
+end
+
+def build_table(files, column_count)
+  rows = (files.size / column_count.to_f).ceil
+  columns = files.each_slice(rows).to_a
+  columns.map { |col| col.values_at(0...rows) }.transpose
+end
+
+def print_table(table, width)
+  table.each do |row|
+    puts row.map { |file| file.to_s.ljust(width) }.join.rstrip
+  end
+end
+
+files = fetch_files
+
+unless files.empty?
+  table = build_table(files, COLUMN_COUNT)
+  print_table(table, files.map(&:size).max + 2)
+end


### PR DESCRIPTION
## 内容
オプション無しのlsコマンドを実装しました。

- 標準ライブラリ(Dir)のみを使用
- カレントディレクトリを対象に、横最大3列で縦方向に並べて表示
- 3の倍数以外の件数(3列目に空欄ができるケース)にも対応

## 実行結果
<!-- ここに自作lsとOS標準lsの実行結果スクショを貼ってください(3の倍数ケース・空欄ができるケースの両方) -->

## rubocop-fjord
<!-- ここに全パスのスクショを貼ってください -->